### PR TITLE
Small bug fix for argument parsing of min MAPQ

### DIFF
--- a/sam_pileup.py
+++ b/sam_pileup.py
@@ -126,7 +126,7 @@ def __main__():
     if options.consensus == 'yes':
         opts += ' -c -T %s -N %s -r %s -I %s' % ( options.theta, options.hapNum, options.fraction, options.phredProb )
     if options.mapqMin:
-        opts += ' -q %d' % (options.mapqMin)
+        opts += ' -q %s' % (options.mapqMin)
     #prepare basic pileup command
     cmd = 'samtools mpileup %s %s -f %s %s > %s'
     cmd_list = None


### PR DESCRIPTION
@kellrott 

The wrapper for samtools pileup is error-ing out on parsing the min MAPQ argument and formatting it for the samtools call.

Error message as follows:

```
File "/home/dnanexus/sam_pileup.py", line 129, in __main__
    opts += ' -q %d' % (options.mapqMin)
TypeError: %d format: a number is required, not str
```

PR-ing a simple patch that is consistent with the parsing of other arguments to unblock this.
